### PR TITLE
Add context example to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,9 +21,21 @@ Usage
   ln -fs ~/.sublime_erb/erb_block.py ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/User
 ```
 
-  Open your User Keybinding File and add the following keybinding
+  Open your User Keybinding File and add the following keybinding to activate the toggle command in all files types
 
+```
   { "keys": ["ctrl+shift+."], "command": "erb" }
+```
+
+  or only in a ruby html context
+
+```
+  { "keys": ["ctrl+shift+<"], "command": "erb", "context":
+    [
+      { "key": "selector", "operator": "equal", "operand": "text.html.ruby, text.haml" }
+    ]
+  }
+```
 
 ### Update To Latest Version ###
 

--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ Usage
   or only in a ruby html context
 
 ```
-  { "keys": ["ctrl+shift+<"], "command": "erb", "context":
+  { "keys": ["ctrl+shift+."], "command": "erb", "context":
     [
       { "key": "selector", "operator": "equal", "operand": "text.html.ruby, text.haml" }
     ]


### PR DESCRIPTION
I didn't want to activate the keybinding on all file types, so I thought it would be a good idea to include an example to limit the keybinding to just a small set of file types, like html.ruby or haml.
