### PR TITLE
Add <%- -%> to the list of ERB blocks.

### DIFF
--- a/erb_block.py
+++ b/erb_block.py
@@ -1,7 +1,7 @@
 import sublime, sublime_plugin
 import re
 
-ERB_BLOCKS = ['<%=  %>', '<%  %>', '<%=  -%>', '<%#  %>', '<%  -%>']
+ERB_BLOCKS = ['<%=  %>', '<%  %>', '<%-  -%>', '<%=  -%>', '<%#  %>', '<%  -%>']
 ERB_REGEX = '<%(=?|-?|#?)\s{2}(-?)%>'
 
 class ErbCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
The Textmate version does this, and this is a super useful shortcut to make sure
that any whitespace is removed before and after the ERB block.
